### PR TITLE
mspm0g1xxx: enable GPIOB power

### DIFF
--- a/soc/arm/ti_mspm0/mspm0g1xxx/soc.c
+++ b/soc/arm/ti_mspm0/mspm0g1xxx/soc.c
@@ -17,8 +17,10 @@ SYSCONFIG_WEAK void SYSCFG_DL_init(void)
 SYSCONFIG_WEAK void SYSCFG_DL_initPower(void)
 {
 	DL_GPIO_reset(GPIOA);
+	DL_GPIO_reset(GPIOB);
 
 	DL_GPIO_enablePower(GPIOA);
+	DL_GPIO_enablePower(GPIOB);
 	delay_cycles(POWER_STARTUP_DELAY);
 }
 


### PR DESCRIPTION
The mspm0g1107 uses the GPIOB base as well.
NOTE: This should be done on driver level instead of SOC level.