### PR TITLE
Bump hal_ti to include driverlib v1.30.00.xx

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -246,7 +246,7 @@ manifest:
         - hal
     - name: hal_ti
       remote: beo_asp
-      revision: 953475cca2638ea8ac6d9f3dfac3d03f8981230f
+      revision: 9c01350e70f706f30018d63302e695634b46d744
       path: modules/hal/ti
       groups:
         - hal


### PR DESCRIPTION
This commit bumps the hal_ti to include the newest driver lib.