### PR TITLE
vendor-prefixes: Add Bang & Olufsen A/S

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -95,6 +95,7 @@ bitmain	Bitmain Technologies
 blues	Blues Wireless
 blutek	BluTek Power
 boe	BOE Technology Group Co., Ltd.
+beo	Bang & Olufsen A/S
 bosch	Bosch Sensortec GmbH
 boundary	Boundary Devices Inc.
 broadmobi	Shanghai Broadmobi Communication Technology Co.,Ltd.


### PR DESCRIPTION
Required to build 'beo' specific drivers.