### PR TITLE
drivers: counter: mspm0 add hw timers drivers

### DIFF
--- a/drivers/counter/CMakeLists.txt
+++ b/drivers/counter/CMakeLists.txt
@@ -49,3 +49,4 @@ zephyr_library_sources_ifdef(CONFIG_COUNTER_SNPS_DW             counter_dw_timer
 zephyr_library_sources_ifdef(CONFIG_COUNTER_SHELL               counter_timer_shell.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_TIMER_RPI_PICO      counter_rpi_pico_timer.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_NXP_MRT             counter_nxp_mrt.c)
+zephyr_library_sources_ifdef(CONFIG_COUNTER_MSPM0	            counter_mspm0.c)

--- a/drivers/counter/Kconfig
+++ b/drivers/counter/Kconfig
@@ -96,4 +96,6 @@ source "drivers/counter/Kconfig.rpi_pico"
 
 source "drivers/counter/Kconfig.nxp_mrt"
 
+source "drivers/counter/Kconfig.mspm0"
+
 endif # COUNTER

--- a/drivers/counter/Kconfig.mspm0
+++ b/drivers/counter/Kconfig.mspm0
@@ -1,0 +1,6 @@
+config COUNTER_MSPM0
+    bool "Driver to interface with MSPM0 hardware clocks"
+    default n
+    depends on DT_HAS_TI_MSPM0_COUNTER_ENABLED
+        help
+            Enables support for TIMERG{0, 6, 7, 12}

--- a/drivers/counter/counter_mspm0.c
+++ b/drivers/counter/counter_mspm0.c
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2024 Bang & Olufsen A/S, Denmark
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ti/driverlib/dl_timerg.h>
+#include <ti/driverlib/dl_timer.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/counter.h>
+
+LOG_MODULE_REGISTER(counter_mspm0, CONFIG_LOG_DEFAULT_LEVEL);
+
+#define DT_DRV_COMPAT ti_mspm0_counter
+// NOTE: it seems(?) that the clocks support multiple input channels but
+// they must be configured with capture mode
+#define MAX_CHANNELS  1
+
+struct counter_mspm0_channel_data {
+	counter_alarm_callback_t callback;
+	void *user_data;
+};
+
+struct counter_mspm0_config {
+	struct counter_config_info info;
+	GPTIMER_Regs *timer;
+	const DL_Timer_ClockConfig clock_cfg;
+	void (*interrupt_init_function)(const struct device *dev);
+};
+
+struct counter_mspm0_data {
+	const struct counter_mspm0_config *config;
+	struct counter_mspm0_channel_data *channel_data;
+	uint32_t freq;
+	DL_Timer_TimerConfig time_cfg;
+	struct k_sem busy_sem;
+};
+
+static int counter_mspm0_start(const struct device *dev)
+{
+	struct counter_mspm0_data *data = dev->data;
+	if (k_sem_take(&data->busy_sem, K_FOREVER) == 0) {
+		const struct counter_mspm0_config *cfg = dev->config;
+		DL_Timer_reset(cfg->timer);
+		DL_Timer_enablePower(cfg->timer);
+
+		DL_Timer_setClockConfig(cfg->timer, (DL_Timer_ClockConfig *)&cfg->clock_cfg);
+		DL_Timer_initTimerMode(cfg->timer, &data->time_cfg);
+
+		DL_Timer_enableInterrupt(cfg->timer, DL_TIMER_INTERRUPT_ZERO_EVENT);
+		cfg->interrupt_init_function(dev);
+
+		DL_Timer_enableClock(cfg->timer);
+		DL_Timer_startCounter(cfg->timer);
+
+		k_sem_give(&data->busy_sem);
+	}
+	return 0;
+}
+
+static int counter_mspm0_stop(const struct device *dev)
+{
+	struct counter_mspm0_data *data = dev->data;
+	if (k_sem_take(&data->busy_sem, K_FOREVER) == 0) {
+		const struct counter_mspm0_config *cfg = dev->config;
+		DL_Timer_stopCounter(cfg->timer);
+
+		k_sem_give(&data->busy_sem);
+	}
+	return 0;
+}
+
+static int counter_mspm0_set_alarm(const struct device *dev, uint8_t chan,
+				   const struct counter_alarm_cfg *alarm_cfg)
+{
+	// NOTE: we only support only 1 channel
+	if (chan != 0) {
+		LOG_ERR("Unsupported channel: %d", chan);
+		return -EINVAL;
+	}
+
+	struct counter_mspm0_data *data = dev->data;
+	if (k_sem_take(&data->busy_sem, K_FOREVER) == 0) {
+
+		struct counter_mspm0_channel_data *channel_data = &data->channel_data[chan];
+		if (channel_data->callback) {
+			LOG_ERR("Callback is already registered");
+			k_sem_give(&data->busy_sem);
+			return -EBUSY;
+		}
+
+		channel_data->callback = alarm_cfg->callback;
+		channel_data->user_data = alarm_cfg->user_data;
+		data->time_cfg.period = alarm_cfg->ticks;
+
+		k_sem_give(&data->busy_sem);
+	}
+	return 0;
+}
+
+static int counter_mspm0_cancel_alarm(const struct device *dev, uint8_t chan)
+{
+	// NOTE: we only support only 1 channel
+	if (chan != 0) {
+		LOG_ERR("Unsupported channel: %d", chan);
+		return -1;
+	}
+
+	struct counter_mspm0_data *data = dev->data;
+	if (k_sem_take(&data->busy_sem, K_FOREVER) == 0) {
+
+		struct counter_mspm0_channel_data *channel_data = &data->channel_data[chan];
+		if (channel_data) {
+			channel_data[chan].callback = NULL;
+		}
+
+		k_sem_give(&data->busy_sem);
+	}
+	return 0;
+}
+
+static uint32_t counter_mspm0_get_freq(const struct device *dev)
+{
+	struct counter_mspm0_data *data = dev->data;
+	const struct counter_mspm0_config *cfg = dev->config;
+	const DL_Timer_ClockConfig clock_cfg = cfg->clock_cfg;
+	// freq = (timer_clk_source / (div_ratio * (prescale + 1))
+	return data->freq / (clock_cfg.divideRatio * (clock_cfg.prescale + 1));
+}
+
+static const struct counter_driver_api counter_mspm0_driver_api = {
+	.start = counter_mspm0_start,
+	.stop = counter_mspm0_stop,
+	.set_alarm = counter_mspm0_set_alarm,
+	.cancel_alarm = counter_mspm0_cancel_alarm,
+	.get_freq = counter_mspm0_get_freq,
+};
+
+static void counter_mspm0_isr(const struct device *dev)
+{
+	struct counter_mspm0_data *data = dev->data;
+	// NOTE: can this be problematic (?) when multiple points call a
+	// critical function (?)
+	if (k_sem_take(&data->busy_sem, K_NO_WAIT) == 0) {
+		// NOTE: its hardcoded to always fetch the 1st available channel
+		struct counter_mspm0_channel_data *channel_data = &data->channel_data[0];
+		counter_alarm_callback_t cb = channel_data->callback;
+		if (cb) {
+			cb(dev, 0, 0, channel_data->user_data);
+		}
+
+		k_sem_give(&data->busy_sem);
+	}
+}
+
+static int counter_mspm0_init(const struct device *dev)
+{
+	struct counter_mspm0_data *data = dev->data;
+	int err = k_sem_init(&data->busy_sem, 0, 1);
+	if (err != 0) {
+		LOG_ERR("Failed to create semaphore: %d", err);
+		return err;
+	}
+
+	k_sem_give(&data->busy_sem);
+	return 0;
+}
+
+/* Macros to assist with the device-specific initialization */
+#define INTERRUPT_INIT_FUNCTION_DECLARATION(inst)                                                  \
+	static void counter_mspm0_interrupt_init_##inst(const struct device *dev)
+
+#define INTERRUPT_INIT_FUNCTION(inst)                                                              \
+	static void counter_mspm0_interrupt_init_##inst(const struct device *dev)                  \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(inst), DT_INST_IRQ(inst, priority), counter_mspm0_isr,    \
+			    DEVICE_DT_INST_GET(inst), 0);                                          \
+		irq_enable(DT_INST_IRQN(inst));                                                    \
+	}
+
+#define COUNTER_MSPM0_INIT(inst)                                                                   \
+                                                                                                   \
+	INTERRUPT_INIT_FUNCTION_DECLARATION(inst);                                                 \
+                                                                                                   \
+	static struct counter_mspm0_channel_data counter##inst##_channel_data[MAX_CHANNELS];       \
+                                                                                                   \
+	const DL_Timer_ClockConfig counter_mspm0_clock_cfg_##inst = {                              \
+		.clockSel = DL_TIMER_CLOCK_BUSCLK,                                                 \
+		.prescale = DT_PROP(DT_DRV_INST(inst), prescaler),                                 \
+		.divideRatio = DT_PROP(DT_DRV_INST(inst), divide_ratio),                           \
+	};                                                                                         \
+                                                                                                   \
+	const struct counter_mspm0_config counter_mspm0_##inst##_cfg = {                           \
+		.info =                                                                            \
+			{                                                                          \
+				.max_top_value = DT_PROP(DT_DRV_INST(inst), resolution) == 32      \
+							 ? BIT64_MASK(32)                          \
+							 : BIT_MASK(16),                           \
+				.flags = 0,                                                        \
+				.channels = 1,                                                     \
+			},                                                                         \
+		.timer = ((GPTIMER_Regs *)DT_INST_REG_ADDR(inst)),                                 \
+		.clock_cfg = counter_mspm0_clock_cfg_##inst,                                       \
+		.interrupt_init_function = counter_mspm0_interrupt_init_##inst,                    \
+	};                                                                                         \
+                                                                                                   \
+	static struct counter_mspm0_data counter_mspm0_##inst##_data = {                           \
+		.config = &counter_mspm0_##inst##_cfg,                                             \
+		.channel_data = counter##inst##_channel_data,                                      \
+		.freq = DT_PROP(DT_DRV_INST(inst), clock_frequency),                               \
+		.time_cfg =                                                                        \
+			{                                                                          \
+				.timerMode = DT_PROP(DT_DRV_INST(inst), mode),                     \
+				.startTimer = DL_TIMER_STOP,                                       \
+			},                                                                         \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, counter_mspm0_init, NULL, &counter_mspm0_##inst##_data,        \
+			      &counter_mspm0_##inst##_cfg, POST_KERNEL,                            \
+			      CONFIG_COUNTER_INIT_PRIORITY, &counter_mspm0_driver_api);            \
+                                                                                                   \
+	INTERRUPT_INIT_FUNCTION(inst)
+
+DT_INST_FOREACH_STATUS_OKAY(COUNTER_MSPM0_INIT)

--- a/dts/arm/ti/mspm0g1xxx.dtsi
+++ b/dts/arm/ti/mspm0g1xxx.dtsi
@@ -5,6 +5,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mspm0_adc.h>
+#include <zephyr/dt-bindings/clock/mspm0_defines.h>
 
 / {
 
@@ -59,6 +60,54 @@
 				#gpio-cells = <2>;
 			};
 		};
+
+		timg0: timg0@40084000 {
+                    compatible = "ti,mspm0-counter";
+                    status = "disabled";
+                    clock-frequency = <32000000>;
+                    prescaler = <255>;
+                    reg = <0x40084000 0x2000>;
+                    divide-ratio = <RATE_2>;
+                    interrupts = <16 0>;
+                    resolution = <16>;
+                    mode = <PERIODIC_DOWN>;
+                };
+
+                timg6: timg6@40868000 {
+                    compatible = "ti,mspm0-counter";
+                    status = "disabled";
+                    clock-frequency = <32000000>;
+                    prescaler = <255>;
+                    reg = <0x40868000 0x2000>;
+                    divide-ratio = <RATE_1>;
+                    interrupts = <17 0>;
+                    resolution = <16>;
+                    mode = <PERIODIC_DOWN>;
+                };
+
+                timg7: timg7@4086a000 {
+                    compatible = "ti,mspm0-counter";
+                    status = "disabled";
+                    prescaler = <255>;
+                    clock-frequency = <32000000>;
+                    reg = <0x4086a000 0x2000>;
+                    divide-ratio = <RATE_1>;
+                    interrupts = <20 0>;
+                    resolution = <16>;
+                    mode = <PERIODIC_DOWN>;
+                };
+
+                timg12: timg12@40870000 {
+                    compatible = "ti,mspm0-counter";
+                    status = "disabled";
+                    clock-frequency = <32000000>;
+                    prescaler = <0>; // prescaler is unused
+                    reg = <0x40870000 0x2000>;
+                    divide-ratio = <RATE_1>;
+                    interrupts = <21 0>;
+                    resolution = <32>;
+                    mode = <PERIODIC_DOWN>;
+                };
 
 		uart0: uart@40108000 {
 			compatible = "ti,mspm0g3xxx-uart";

--- a/dts/arm/ti/mspm0g3xxx.dtsi
+++ b/dts/arm/ti/mspm0g3xxx.dtsi
@@ -5,6 +5,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mspm0_adc.h>
+#include <zephyr/dt-bindings/clock/mspm0_defines.h>
 
 / {
 
@@ -61,6 +62,54 @@
 			};
 
 		};
+
+                timg0: timg0@40084000 {
+                    compatible = "ti,mspm0-counter";
+                    status = "disabled";
+                    clock-frequency = <32000000>;
+                    prescaler = <255>;
+                    reg = <0x40084000 0x2000>;
+                    divide-ratio = <RATE_2>;
+                    interrupts = <16 0>;
+                    resolution = <16>;
+                    mode = <PERIODIC_DOWN>;
+                };
+
+                timg6: timg6@40868000 {
+                    compatible = "ti,mspm0-counter";
+                    status = "disabled";
+                    clock-frequency = <32000000>;
+                    prescaler = <255>;
+                    reg = <0x40868000 0x2000>;
+                    divide-ratio = <RATE_1>;
+                    interrupts = <17 0>;
+                    resolution = <16>;
+                    mode = <PERIODIC_DOWN>;
+                };
+
+                timg7: timg7@4086a000 {
+                    compatible = "ti,mspm0-counter";
+                    status = "disabled";
+                    clock-frequency = <32000000>;
+                    prescaler = <255>;
+                    reg = <0x4086a000 0x2000>;
+                    divide-ratio = <RATE_1>;
+                    interrupts = <20 0>;
+                    resolution = <16>;
+                    mode = <PERIODIC_DOWN>;
+                };
+
+                timg12: timg12@40870000 {
+                    compatible = "ti,mspm0-counter";
+                    status = "disabled";
+                    clock-frequency = <32000000>;
+                    prescaler = <0>; // prescaler is unused
+                    reg = <0x40870000 0x2000>;
+                    divide-ratio = <RATE_1>;
+                    interrupts = <21 0>;
+                    resolution = <32>;
+                    mode = <PERIODIC_DOWN>;
+                };
 
 		uart0: uart@40108000 {
 			compatible = "ti,mspm0g3xxx-uart";

--- a/dts/bindings/counter/ti,mspm0-counter.yaml
+++ b/dts/bindings/counter/ti,mspm0-counter.yaml
@@ -1,0 +1,30 @@
+# Copyright (C) 2024 Bang & Olufsen A/S, Denmark
+#
+# SPDX-License-Identifier: LicenseRef-BnOProprietary
+
+description: Driver to enable MSPM0 Hardware Timers. Currently it only supports TIMG{0, 6, 7, 12}.
+
+include: [base.yaml]
+
+compatible: "ti,mspm0-counter"
+
+properties:
+  prescaler:
+    type: int
+    required: true
+  mode:
+    type: int
+    required: true
+  divide-ratio:
+    type: int
+    required: true
+  reg:
+    required: true
+  interrupts:
+    required: true
+  resolution:
+    type: int
+    required: true
+  clock-frequency:
+    type: int
+    required: true

--- a/include/zephyr/dt-bindings/clock/mspm0_defines.h
+++ b/include/zephyr/dt-bindings/clock/mspm0_defines.h
@@ -1,0 +1,26 @@
+// Copyright (C) 2024 Bang & Olufsen A/S, Denmark
+//
+// SPDX-License-Identifier: LicenseRef-BnOProprietary
+
+#ifndef TI_DT_BINDINGS_MSPM0_H
+#define TI_DT_BINDINGS_MSPM0_H
+
+// check <ti/driverlib/dl_timer.h>
+
+#define ONE_SHOT_DOWN    0
+#define ONE_SHOT_UP      32
+#define PERIODIC_DOWN    2
+#define PERIODIC_UP      34
+#define ONE_SHOT_UP_DOWN 16
+#define PERIODIC_UP_DOWN 18
+
+#define RATE_1 1
+#define RATE_2 2
+#define RATE_3 3
+#define RATE_4 4
+#define RATE_5 5
+#define RATE_6 6
+#define RATE_7 7
+#define RATE_8 8
+
+#endif


### PR DESCRIPTION
This pr introduces a new device driver to use some of the mspm0 hardware timers. More specifically TimerG{0, 6, 7, 12}. There are more timers available but they need to be configured differently, so for the time being, i decided to keep it simple for our use cases. More specifically, we can now set the following properties for a timer (in dts):

1. prescale
2. divide-ration
3. resolution
4. mode (ONE_SHOT/PERIODIC/other combinations)

The period has to be configured from the application part, as we are leveraging Zephyr's counter timer API. We are passing the period (ticks) as part of the configuration for the counter alongside with the callback. Also, several of the timers support multiple channels, but are configured to be in different modes that would make things more complicated. Also, they are also other modes/properties available that are tied to specific timers, but we could also add them on a future version. MAX_CHANNELS are hardcoded to 1, so some parts of the counter API are kind of unused.

Example: to use TimerG12 to run a periodic timer every 1s

```
/*
 * Timer clock configuration to be sourced by BUSCLK /  (32000000 Hz)
 * timerClkFreq = (timerClkSrc / (timerClkDivRatio * (timerClkPrescale + 1)))
 *   32000000 Hz = 32000000 Hz / (1 * (0 + 1))
 * timerPeriod = (32000000 Hz) - 1
 */

&timg12 {
    status = "okay";
    compatible = "ti,mspm0-counter";
};

const struct device *dev0 = DEVICE_DT_GET(DT_NODELABEL(timg12));
alarm_cfg.ticks = counter_us_to_ticks(dev0, 1000000);
alarm_cfg.callback = my_isr;
alarm_cfg.user_data = &alarm_cfg;
counter_set_channel_alarm(dev0, 0, &alarm_cfg);
counter_start(dev0);
```