### PR TITLE
drivers: i2c: fix i2c scan for mspm0

### DIFF
--- a/drivers/i2c/i2c_mspm0g3xxx.c
+++ b/drivers/i2c/i2c_mspm0g3xxx.c
@@ -289,11 +289,6 @@ static int i2c_mspm0g3xxx_transmit(const struct device *dev, struct i2c_msg msg,
 	const struct i2c_mspm0g3xxx_config *config = dev->config;
 	struct i2c_mspm0g3xxx_data *data = dev->data;
 
-	/* Sending address without data is not supported */
-	if (msg.len == 0) {
-		return -EIO;
-	}
-
 	/* Update cached msg and addr */
 	data->msg = msg;
 	data->addr = addr;


### PR DESCRIPTION
This commit makes it possible to scan i2c devices. We might go against the i2c standard here, as the i2c standard does in fact not support probing. But this is how it's done in Zephyr and Linux, so let's allow it to be used for that.