### PR TITLE
drivers: i2c: mspm0: add transfer timeout

### DIFF
--- a/drivers/i2c/Kconfig.mspm0g3xxx
+++ b/drivers/i2c/Kconfig.mspm0g3xxx
@@ -16,4 +16,12 @@ config I2C_MSPM0G3XXX_TARGET_SUPPORT
 	  Enable support for i2c-target functionality
 	  for TI MSPM0G3XXX driver.
 
+config I2C_MSPM0G3XXX_TRANSFER_TIMEOUT
+	int "Transfer timeout [ms]"
+	default 100
+	help
+	  Timeout in milliseconds used for each I2C transfer.
+	  0 means that the driver should use the K_FOREVER value,
+	  i.e. it should wait as long as necessary.
+
 endif # I2C_MSPM0G3XXX


### PR DESCRIPTION
Previously the controller would be stuck in a busy loop waiting for the target to respond.
If the target is not attached it would mean that we'd end up in a situation where the busy loop would wait indefinite. Also in general using a busy wait is performance heavy where we can offload the wait using sem synchronization.