### PR TITLE
drivers: counter_mspm0: divide ratios patch

### DIFF
--- a/drivers/counter/counter_mspm0.c
+++ b/drivers/counter/counter_mspm0.c
@@ -107,8 +107,8 @@ static uint32_t counter_mspm0_get_freq(const struct device *dev)
 	struct counter_mspm0_data *data = dev->data;
 	const struct counter_mspm0_config *cfg = dev->config;
 	const DL_Timer_ClockConfig clock_cfg = cfg->clock_cfg;
-	// freq = (timer_clk_source / (div_ratio * (prescale + 1))
-	return data->freq / (clock_cfg.divideRatio * (clock_cfg.prescale + 1));
+	// freq = (timer_clk_source / ((div_ratio + 1) * (prescale + 1))
+	return data->freq / ((clock_cfg.divideRatio + 1) * (clock_cfg.prescale + 1));
 }
 
 static const struct counter_driver_api counter_mspm0_driver_api = {

--- a/include/zephyr/dt-bindings/clock/mspm0_defines.h
+++ b/include/zephyr/dt-bindings/clock/mspm0_defines.h
@@ -7,6 +7,7 @@
 
 // check <ti/driverlib/dl_timer.h>
 
+// check DL_TIMER_TIMER_MODE
 #define ONE_SHOT_DOWN    0
 #define ONE_SHOT_UP      32
 #define PERIODIC_DOWN    2
@@ -14,13 +15,14 @@
 #define ONE_SHOT_UP_DOWN 16
 #define PERIODIC_UP_DOWN 18
 
-#define RATE_1 1
-#define RATE_2 2
-#define RATE_3 3
-#define RATE_4 4
-#define RATE_5 5
-#define RATE_6 6
-#define RATE_7 7
-#define RATE_8 8
+// check DL_TIMER_CLOCK_DIVIDE
+#define RATE_1 0
+#define RATE_2 1
+#define RATE_3 2
+#define RATE_4 3
+#define RATE_5 4
+#define RATE_6 5
+#define RATE_7 6
+#define RATE_8 7
 
 #endif


### PR DESCRIPTION
I assumed that the values for the clock divide ratios would actually match their name;
Ratio1 -> 1, Ratio2 -> 2, etc. But that doesn't seem to be the case. Ratio1 -> actually has value of 0, Ratio2 -> 1. etc. Also updated the function in the counter driver to calculate correctly the frequency for this case.