### PR TITLE
drivers: pwm: pwm_mspm0: use sysclk

### DIFF
--- a/drivers/pwm/pwm_mspm0.c
+++ b/drivers/pwm/pwm_mspm0.c
@@ -165,7 +165,7 @@ static int pwm_mspm0_init(const struct device *dev)
 				.prescale = DT_PROP(DT_DRV_INST(inst), ti_prescaler),              \
 			},                                                                         \
 		.pwm_mode = DT_PROP(DT_DRV_INST(inst), ti_mode),                                   \
-		.frequency = DT_PROP(DT_DRV_INST(inst), ti_clock_frequency),                       \
+		.frequency = DT_INST_PROP_BY_PHANDLE(inst, clocks, clock_frequency),               \
 		.pinctrl = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                                   \
 	};                                                                                         \
                                                                                                    \

--- a/dts/arm/ti/mspm0g1xxx.dtsi
+++ b/dts/arm/ti/mspm0g1xxx.dtsi
@@ -110,14 +110,14 @@
                 };
 
 		tima0: tima0@40860000 {
-                    compatible      = "ti,mspm0-pwm";
-                    status          = "disabled";
-                    ti,clock-frequency = <32000000>;
-                    reg                = <0x40860000 0x2000>;
-                    ti,divide-ratio    = <RATE_1>;
-                    ti,prescaler       = <0>;
-                    ti,mode            = <EDGE_ALIGN_UP>;
-		    #pwm-cells 	       = <3>;
+                    compatible = "ti,mspm0-pwm";
+                    status = "disabled";
+                    clocks = <&sysclk>;
+                    reg = <0x40860000 0x2000>;
+                    ti,divide-ratio = <RATE_1>;
+                    ti,prescaler = <0>;
+                    ti,mode = <EDGE_ALIGN_UP>;
+                    #pwm-cells = <3>;
 		};
 
 		uart0: uart@40108000 {

--- a/dts/bindings/pwm/ti,mspm0-pwm.yaml
+++ b/dts/bindings/pwm/ti,mspm0-pwm.yaml
@@ -34,12 +34,6 @@ properties:
         - 16: "Configure the pwm timer as Center Align"
         - 32: "Configure the pwm timer as Edge Align Up"
 
-  ti,clock-frequency:
-    const: 32000000
-    type: int
-    required: true
-    description: Defines the clock frequency that the module will use. This value is required and should be treated as read-only; it must not be modified after initial configuration.
-
   ti,divide-ratio:
     type: int
     required: true


### PR DESCRIPTION
Instead of using hardcoded frequency, parse the sysclock. Also purge ti,clock-frequency property