### PR TITLE
mspm0g3xxx: Add option to enable hfxt for CAN

### DIFF
--- a/drivers/can/Kconfig.mspm0g3xxx
+++ b/drivers/can/Kconfig.mspm0g3xxx
@@ -26,4 +26,10 @@ config CAN_MAX_EXT_ID_FILTER
 	  Defines the maximum number of filters with extended ID (29-bit)
 	  that can be added by the application.
 
+config CAN_USE_HFXT
+       bool "Enable HFXT support for CAN"
+       default false
+       help
+           A hack to get CAN to work with HFXT support
+
 endif # CAN_MSPM0G3XXX_CANFD

--- a/soc/arm/ti_mspm0/mspm0g3xxx/soc.h
+++ b/soc/arm/ti_mspm0/mspm0g3xxx/soc.h
@@ -25,7 +25,11 @@ extern "C" {
 /*!
  * @brief If true, enables HFXT to be used for CAN, otherwise enables PLL using SYSOSC
  */
-#define SOC_MSPM0_CAN_USE_HFXT      (false) 
+#if CONFIG_CAN_USE_HFXT
+#define SOC_MSPM0_CAN_USE_HFXT (true)
+#else
+#define SOC_MSPM0_CAN_USE_HFXT (false)
+#endif
 /*!
  * @brief CPU frequency in Hz
  */


### PR DESCRIPTION
We need to be able to run CAN using an external clock source, since the in chip package is not up to spec. TI had already added a way to configure the clock pins via macros. I am just adding a config option so we can enable this only on the HDMI 4-2 board