### PR TITLE
drivers: gpio: mspm0g3xxx: allow configuration of open-drain outputs

### DIFF
--- a/drivers/gpio/gpio_mspm0g3xxx.c
+++ b/drivers/gpio/gpio_mspm0g3xxx.c
@@ -79,7 +79,7 @@ static int gpio_mspm0g3xxx_pin_configure(const struct device *port, gpio_pin_t p
 						  : (flags & GPIO_PULL_DOWN)
 							  ? DL_GPIO_RESISTOR_PULL_DOWN
 							  : DL_GPIO_RESISTOR_NONE,
-						  DL_GPIO_DRIVE_STRENGTH_LOW, DL_GPIO_HIZ_DISABLE);
+						  DL_GPIO_DRIVE_STRENGTH_LOW, (flags & GPIO_OPEN_DRAIN) ? DL_GPIO_HIZ_ENABLE : DL_GPIO_HIZ_DISABLE);
 
 		/* Set initial state */
 		if (flags & GPIO_OUTPUT_INIT_HIGH) {


### PR DESCRIPTION
Check the GPIO_OPEN_DRAIN flag and set the corresponding HIZ1 bit in the PINCM register.