### PR TITLE
mspm0 counter driver fixes

### DIFF
--- a/drivers/counter/counter_mspm0.c
+++ b/drivers/counter/counter_mspm0.c
@@ -32,7 +32,7 @@ struct counter_mspm0_config {
 struct counter_mspm0_data {
 	const struct counter_mspm0_config *config;
 	struct counter_mspm0_channel_data *channel_data;
-	uint32_t freq;
+	uint32_t frequency;
 	DL_Timer_TimerConfig time_cfg;
 	struct k_spinlock spinlock;
 };
@@ -63,7 +63,7 @@ static int counter_mspm0_set_alarm(const struct device *dev, uint8_t chan,
 	// NOTE: we only support only 1 channel
 	if (chan != 0) {
 		LOG_ERR("Unsupported channel: %d", chan);
-		return -EINVAL;
+		return -ENOTSUP;
 	}
 
 	struct counter_mspm0_data *data = dev->data;
@@ -89,7 +89,7 @@ static int counter_mspm0_cancel_alarm(const struct device *dev, uint8_t chan)
 	// NOTE: we only support only 1 channel
 	if (chan != 0) {
 		LOG_ERR("Unsupported channel: %d", chan);
-		return -1;
+		return -ENOTSUP;
 	}
 
 	struct counter_mspm0_data *data = dev->data;
@@ -108,7 +108,7 @@ static uint32_t counter_mspm0_get_freq(const struct device *dev)
 	const struct counter_mspm0_config *cfg = dev->config;
 	const DL_Timer_ClockConfig clock_cfg = cfg->clock_cfg;
 	// freq = (timer_clk_source / ((div_ratio + 1) * (prescale + 1))
-	return data->freq / ((clock_cfg.divideRatio + 1) * (clock_cfg.prescale + 1));
+	return data->frequency / ((clock_cfg.divideRatio + 1) * (clock_cfg.prescale + 1));
 }
 
 static const struct counter_driver_api counter_mspm0_driver_api = {
@@ -139,6 +139,7 @@ static int counter_mspm0_init(const struct device *dev)
 	DL_Timer_enableInterrupt(cfg->timer, DL_TIMER_INTERRUPT_ZERO_EVENT);
 	cfg->interrupt_init_function(dev);
 	DL_Timer_enableClock(cfg->timer);
+
 	return 0;
 }
 
@@ -178,7 +179,7 @@ static int counter_mspm0_init(const struct device *dev)
 	static struct counter_mspm0_data counter_mspm0_##inst##_data = {                           \
 		.config = &counter_mspm0_##inst##_cfg,                                             \
 		.channel_data = counter##inst##_channel_data,                                      \
-		.freq = DT_PROP(DT_DRV_INST(inst), clock_frequency),                               \
+		.frequency = DT_INST_PROP_BY_PHANDLE(inst, clocks, clock_frequency),               \
 		.time_cfg =                                                                        \
 			{                                                                          \
 				.timerMode = DT_PROP(DT_DRV_INST(inst), mode),                     \

--- a/dts/arm/ti/mspm0g1xxx.dtsi
+++ b/dts/arm/ti/mspm0g1xxx.dtsi
@@ -120,6 +120,18 @@
                     #pwm-cells = <3>;
 		};
 
+		tima1: tima0@40862000 {
+                    compatible = "ti,mspm0-counter";
+                    status = "disabled";
+                    clocks = <&sysclk>;
+                    prescaler = <0>;
+                    reg = <0x40862000 0x2000>;
+                    divide-ratio = <RATE_1>;
+                    interrupts = <19 0>;
+                    resolution = <16>;
+                    mode = <PERIODIC_UP>;
+		};
+
 		uart0: uart@40108000 {
 			compatible = "ti,mspm0g3xxx-uart";
 			reg = <0x40108000 0x2000>;

--- a/dts/arm/ti/mspm0g1xxx.dtsi
+++ b/dts/arm/ti/mspm0g1xxx.dtsi
@@ -64,7 +64,7 @@
 		timg0: timg0@40084000 {
                     compatible = "ti,mspm0-counter";
                     status = "disabled";
-                    clock-frequency = <32000000>;
+                    clocks = <&sysclk>;
                     prescaler = <255>;
                     reg = <0x40084000 0x2000>;
                     divide-ratio = <RATE_2>;
@@ -76,7 +76,7 @@
                 timg6: timg6@40868000 {
                     compatible = "ti,mspm0-counter";
                     status = "disabled";
-                    clock-frequency = <32000000>;
+                    clocks = <&sysclk>;
                     prescaler = <255>;
                     reg = <0x40868000 0x2000>;
                     divide-ratio = <RATE_1>;
@@ -88,8 +88,8 @@
                 timg7: timg7@4086a000 {
                     compatible = "ti,mspm0-counter";
                     status = "disabled";
+                    clocks = <&sysclk>;
                     prescaler = <255>;
-                    clock-frequency = <32000000>;
                     reg = <0x4086a000 0x2000>;
                     divide-ratio = <RATE_1>;
                     interrupts = <20 0>;
@@ -100,7 +100,7 @@
                 timg12: timg12@40870000 {
                     compatible = "ti,mspm0-counter";
                     status = "disabled";
-                    clock-frequency = <32000000>;
+                    clocks = <&sysclk>;
                     prescaler = <0>; // prescaler is unused
                     reg = <0x40870000 0x2000>;
                     divide-ratio = <RATE_1>;

--- a/dts/arm/ti/mspm0g3xxx.dtsi
+++ b/dts/arm/ti/mspm0g3xxx.dtsi
@@ -66,7 +66,7 @@
                 timg0: timg0@40084000 {
                     compatible = "ti,mspm0-counter";
                     status = "disabled";
-                    clock-frequency = <32000000>;
+                    clocks = <&sysclk>;
                     prescaler = <255>;
                     reg = <0x40084000 0x2000>;
                     divide-ratio = <RATE_2>;
@@ -78,7 +78,7 @@
                 timg6: timg6@40868000 {
                     compatible = "ti,mspm0-counter";
                     status = "disabled";
-                    clock-frequency = <32000000>;
+                    clocks = <&sysclk>;
                     prescaler = <255>;
                     reg = <0x40868000 0x2000>;
                     divide-ratio = <RATE_1>;
@@ -90,7 +90,7 @@
                 timg7: timg7@4086a000 {
                     compatible = "ti,mspm0-counter";
                     status = "disabled";
-                    clock-frequency = <32000000>;
+                    clocks = <&sysclk>;
                     prescaler = <255>;
                     reg = <0x4086a000 0x2000>;
                     divide-ratio = <RATE_1>;
@@ -102,7 +102,7 @@
                 timg12: timg12@40870000 {
                     compatible = "ti,mspm0-counter";
                     status = "disabled";
-                    clock-frequency = <32000000>;
+                    clocks = <&sysclk>;
                     prescaler = <0>; // prescaler is unused
                     reg = <0x40870000 0x2000>;
                     divide-ratio = <RATE_1>;

--- a/dts/bindings/counter/ti,mspm0-counter.yaml
+++ b/dts/bindings/counter/ti,mspm0-counter.yaml
@@ -25,6 +25,3 @@ properties:
   resolution:
     type: int
     required: true
-  clock-frequency:
-    type: int
-    required: true


### PR DESCRIPTION
tldr:
1. return the correct error codes according to spec
2. parse sysclock instead of hardcoding the speed
3. add tima1 timer on mspm0g1xxx.dtsi