### PR TITLE
dts: ti: mspm0g1x0x_g3x0x: [HACK] sysclk to 80MHz

### DIFF
--- a/dts/arm/ti/mspm0g1x0x_g3x0x/mspm0g1x0x_g3x0x.dtsi
+++ b/dts/arm/ti/mspm0g1x0x_g3x0x/mspm0g1x0x_g3x0x.dtsi
@@ -25,7 +25,7 @@
 
 	sysclk: system-clock {
 		compatible = "fixed-clock";
-		clock-frequency = <DT_FREQ_M(32)>;
+		clock-frequency = <DT_FREQ_M(80)>;
 		#clock-cells = <0>;
 	};
 


### PR DESCRIPTION
The latest TI changes in 4.1.0 seems that broke the previous clock behavior. The sysclk is hardcoded to 32MHz even though the actual clock might be higher or lower. Until we identify the actual issue or the official mspm0 pr fixes the issue
(https://github.com/zephyrproject-rtos/zephyr/pull/88725) we are hardcoding the sysclk frequency to 80MHz.