### PR TITLE
dts: ti: mspm0g1x0x_g3x0x: fixup uart3 compatible

### DIFF
--- a/dts/arm/ti/mspm0g1x0x_g3x0x/mspm0g1x0x_g3x0x.dtsi
+++ b/dts/arm/ti/mspm0g1x0x_g3x0x/mspm0g1x0x_g3x0x.dtsi
@@ -198,7 +198,7 @@
 		};
 
 		uart3: uart@40500000 {
-			compatible = "ti,mspm0g3xxx-uart";
+			compatible = "ti,mspm0-uart";
 			reg = <0x40500000 0x2000>;
 			interrupts = <3 0>;
 			current-speed = <115200>;


### PR DESCRIPTION
The commit which added uart3 to the mspm0g devicetree was cherry-picked from a previous driver release from TI. Since this TI release, the uart compatible changed.
The patch was not updated accordingly, though.

Fixup the compatible for uart3 in mspm0g1x0x_g3x0x.

Fixes: 81a7b740c564 ("mspm0gxxxx: add uart3 to dtsi")