### PR TITLE
dts: ti: mspm0g: fixup pinctrl for can0_tx_pa12

### DIFF
--- a/dts/arm/ti/mspm0g1x0x_g3x0x/mspm0g3xxx-pinctrl.dtsi
+++ b/dts/arm/ti/mspm0g1x0x_g3x0x/mspm0g3xxx-pinctrl.dtsi
@@ -8,7 +8,7 @@
 	};
 
 	can0_tx_pa12: can0_tx_pa12 {
-		pinmux = <MSP_PINMUX(34,MSPM0_PIN_FUNCTION_6)>;
+		pinmux = <MSP_PINMUX(34,MSPM0_PIN_FUNCTION_5)>;
 	};
 
 };

--- a/dts/arm/ti/mspm0gx51x/mspm0g3xxx-pinctrl.dtsi
+++ b/dts/arm/ti/mspm0gx51x/mspm0g3xxx-pinctrl.dtsi
@@ -8,7 +8,7 @@
 	};
 
 	can0_tx_pa12: can0_tx_pa12 {
-		pinmux = <MSP_PINMUX(34,MSPM0_PIN_FUNCTION_6)>;
+		pinmux = <MSP_PINMUX(34,MSPM0_PIN_FUNCTION_5)>;
 	};
 
 };


### PR DESCRIPTION
As per the pinmux table in the datasheet for mspm0g3507[1] the correct function for pa12 to become can0 tx is pinfunction 5. Fix the mistake in all relevant places.

[1] table 6.1 in https://www.ti.com/lit/ds/symlink/mspm0g3507.pdf