### PR TITLE
drivers: led: lp5569: wait for chip to power up after setting chip_en=1

### DIFF
--- a/drivers/led/lp5569.c
+++ b/drivers/led/lp5569.c
@@ -127,6 +127,8 @@ static int lp5569_enable(const struct device *dev)
 		return ret;
 	}
 
+	k_msleep(1);
+
 	ret = i2c_reg_write_byte_dt(&config->bus, LP5569_MISC,
 				    LP5569_POWERSAVE_EN | LP5569_EN_AUTO_INCR |
 					    (config->cp_mode << LP5569_CP_MODE_SHIFT));


### PR DESCRIPTION
The datasheet says to wait at least 500 us. Since the Zephyr documentation cautions about using k_usleep(), double that figure and do a k_msleep(1).