### PR TITLE
Add led current setting on LED API and lp5569 

### DIFF
--- a/drivers/led/Kconfig
+++ b/drivers/led/Kconfig
@@ -14,6 +14,13 @@ module = LED
 module-str = led
 source "subsys/logging/Kconfig.template.log_config"
 
+config LED_CURRENT_SETTING
+	bool "Expose means to tweak consumed current to led(s)"
+	help
+	  A few controller can control the amount of current delivered
+	  to led(s). Depending on the hardware, this can be useful to
+	  prevent damages (though is could generate some if badly used).
+
 config LED_INIT_PRIORITY
 	int "LED initialization priority"
 	default 90

--- a/drivers/led/led_shell.c
+++ b/drivers/led/led_shell.c
@@ -330,6 +330,36 @@ cmd_write_channels(const struct shell *sh, size_t argc, char **argv)
 	return err;
 }
 
+#ifdef CONFIG_LED_CURRENT_SETTING
+static int cmd_set_current(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev;
+	unsigned long current;
+	char *end_ptr;
+	uint32_t led;
+	int err;
+
+	err = parse_common_args(sh, argv, &dev, &led);
+	if (err < 0) {
+		return err;
+	}
+
+	current = strtoul(argv[arg_idx_value], &end_ptr, 0);
+	if (*end_ptr != '\0') {
+		shell_error(sh, "Invalid LED current parameter %s",
+			    argv[arg_idx_value]);
+		return -EINVAL;
+	}
+
+	err = led_set_current(dev, led, current);
+	if (err) {
+		shell_error(sh, "Error: %d", err);
+	}
+
+	return err;
+}
+#endif /* CONFIG_LED_CURRENT_SETTING */
+
 static bool device_is_led(const struct device *dev)
 {
 	return DEVICE_API_IS(led, dev);
@@ -361,6 +391,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD_ARG(write_channels, &dsub_device_name,
 		      "<device> <chan> <value 0 [0-255]> ... <value N>", cmd_write_channels, 4,
 		      MAX_CHANNEL_ARGS - 1),
+	COND_CODE_1(IS_ENABLED(CONFIG_LED_CURRENT_SETTING),
+		    (SHELL_CMD_ARG(set_current, &dsub_device_name,
+				  "<device> <led> <current N [in micro-amps]>",
+				   cmd_set_current, 4, 0),), ())
 	SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(led, &sub_led, "LED commands", NULL);

--- a/drivers/led/lp5569.c
+++ b/drivers/led/lp5569.c
@@ -42,9 +42,18 @@ LOG_MODULE_REGISTER(lp5569, CONFIG_LED_LOG_LEVEL);
 #define LP5569_MASTER_FADER2     0x47
 #define LP5569_MASTER_FADER3     0x48
 
+#ifdef CONFIG_LED_CURRENT_SETTING
+/* Base register for controlling maximum delivered current */
+#define LP5569_LED0_CURRENT 0x22
+#define LP5569_MAX_CURRENT  25500
+#endif /* CONFIG_LED_CURRENT_SETTING */
+
 struct lp5569_config {
 	struct i2c_dt_spec bus;
 	struct gpio_dt_spec enable_gpio;
+#ifdef CONFIG_LED_CURRENT_SETTING
+	const uint32_t current_limit;
+#endif /* CONFIG_LED_CURRENT_SETTING */
 	const uint8_t cp_mode;
 };
 
@@ -138,6 +147,30 @@ static int lp5569_set_group_brightness(const struct device *dev, uint8_t group_i
 
 	return 0;
 }
+
+#ifdef CONFIG_LED_CURRENT_SETTING
+static int lp5569_set_current(const struct device *dev, uint32_t led, uint32_t micro_amps)
+{
+	const struct lp5569_config *config = dev->config;
+	uint8_t val;
+	int ret;
+
+	if (led >= LP5569_NUM_LEDS) {
+		return -EINVAL;
+	}
+
+	/* we should never exceed the device's limitations */
+	micro_amps = MIN(micro_amps, config->current_limit);
+	val = micro_amps / 100;
+
+	ret = i2c_reg_write_byte_dt(&config->bus, LP5569_LED0_CURRENT + led, val);
+	if (ret < 0) {
+		LOG_ERR("LED reg update failed");
+	}
+
+	return ret;
+}
+#endif /* CONFIG_LED_CURRENT_SETTING */
 
 static int lp5569_enable(const struct device *dev)
 {
@@ -255,6 +288,9 @@ static DEVICE_API(led, lp5569_led_api) = {
 	.off = lp5569_led_off,
 	.write_channels = lp5569_write_channels,
 	.set_group_brightness = lp5569_set_group_brightness,
+#ifdef CONFIG_LED_CURRENT_SETTING
+	.set_current = lp5569_set_current,
+#endif /* CONFIG_LED_CURRENT_SETTING */
 };
 
 #define LP5569_DEFINE(id)                                                                          \
@@ -262,7 +298,9 @@ static DEVICE_API(led, lp5569_led_api) = {
 		.bus = I2C_DT_SPEC_INST_GET(id),                                                   \
 		.enable_gpio = GPIO_DT_SPEC_INST_GET_OR(id, enable_gpios, {0}),                    \
 		.cp_mode = DT_ENUM_IDX(DT_DRV_INST(id), charge_pump_mode),                         \
-	};                                                                                         \
+		COND_CODE_1(IS_ENABLED(CONFIG_LED_CURRENT_SETTING),                                \
+			    (.current_limit = DT_PROP_OR(id, led-max-microamp,                     \
+							 LP5569_MAX_CURRENT)), ()) }; \
                                                                                                    \
 	PM_DEVICE_DT_INST_DEFINE(id, lp5569_pm_action);                                            \
                                                                                                    \

--- a/dts/bindings/led/led-controller.yaml
+++ b/dts/bindings/led/led-controller.yaml
@@ -3,6 +3,15 @@
 
 # Common fields for LED controllers and child LEDs
 
+properties:
+  led-max-microamp:
+      type: int
+      description: |
+        Maximum current that can be delivered to the led. Meant to limit
+        the amount a current a led can take, so tweaking delivered current
+        will not go over this value. Beware that, if wrongly set, it will
+        enable the possibility of hardware damage led side.
+
 child-binding:
   description: LED child node
   properties:

--- a/dts/bindings/led/ti,lp5569.yaml
+++ b/dts/bindings/led/ti,lp5569.yaml
@@ -2,7 +2,7 @@ description: TI LP5569 LED
 
 compatible: "ti,lp5569"
 
-include: i2c-device.yaml
+include: [led-controller.yaml, i2c-device.yaml]
 
 properties:
   enable-gpios:

--- a/include/zephyr/drivers/led.h
+++ b/include/zephyr/drivers/led.h
@@ -117,6 +117,16 @@ typedef int (*led_api_write_channels)(const struct device *dev,
 typedef int (*led_api_set_group_brightness)(const struct device *dev,
 						uint8_t group_index,
 						uint8_t brightness);
+
+/**
+ * @typedef led_api_set_current()
+ * @brief Callback API to set the current of a LED.
+ *
+ * @see led_set_current() for argument descriptions.
+ */
+typedef int (*led_api_set_current)(const struct device *dev, uint32_t led,
+				   uint32_t micro_amps);
+
 /**
  * @brief LED driver API
  */
@@ -131,6 +141,9 @@ __subsystem struct led_driver_api {
 	led_api_set_color set_color;
 	led_api_write_channels write_channels;
 	led_api_set_group_brightness set_group_brightness;
+#ifdef CONFIG_LED_CURRENT_SETTING
+	led_api_set_current set_current;
+#endif /* CONFIG_LED_CURRENT_SETTING */
 };
 
 /**
@@ -363,6 +376,40 @@ static inline int z_impl_led_set_group_brightness(const struct device *dev,
 
 	return api->set_group_brightness(dev, group_index, brightness);
 }
+
+/**
+ * @brief Set maximum current that can be delivered to a LED
+ *
+ * Sets a limit on the current (micro_amps) that can be supplied
+ * to the specified LED. If the requested value exceeds the device's
+ * maximum capability, it will be capped accordingly.
+ *
+ * Note: The actual resolution of the current setting depends on the
+ * underlying LED controller. Values may be rounded down to the nearest
+ * supported increment if fine-grained control is not available.
+ *
+ * @param dev LED device
+ * @param led LED number
+ * @param micro_amps ampere limit (relative to LED device maximum capability)
+ * @return 0 on success, negative on error
+ */
+#ifdef CONFIG_LED_CURRENT_SETTING
+__syscall int led_set_current(const struct device *dev, uint32_t led,
+			      uint32_t micro_amps);
+
+static inline int z_impl_led_set_current(const struct device *dev, uint32_t led,
+					 uint32_t micro_amps)
+{
+	const struct led_driver_api *api =
+		(const struct led_driver_api *)dev->api;
+
+	if (api->set_current == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->set_current(dev, led, micro_amps);
+}
+#endif /* CONFIG_LED_CURRENT_SETTING */
 
 /*
  * LED DT helpers.


### PR DESCRIPTION
Currently setting micro-amps. Not the most user friendly, but going to a 0-255 type of setting does not give a good granularity.
(not on lp5569 though, since it does take a 0-255 range of value, but we cannot generalize from it)