### PR TITLE
drivers: led: lp5569: exponential brightness curves

### DIFF
--- a/drivers/led/lp5569.c
+++ b/drivers/led/lp5569.c
@@ -39,6 +39,7 @@ LOG_MODULE_REGISTER(lp5569, CONFIG_LED_LOG_LEVEL);
 /* PWM base Register for controlling the duty-cycle */
 #define LP5569_LED0_PWM          0x16
 #define LP5569_LED0_CONTROL      0x7
+#define LP5569_EXP_EN            BIT(3)
 #define LP5569_MF_MAPPING_FADER1 BIT(5)
 #define LP5569_MASTER_FADER1     0x46
 #define LP5569_MASTER_FADER2     0x47
@@ -256,7 +257,8 @@ static int lp5569_enable(const struct device *dev)
 		const uint8_t current_led = LP5569_LED0_CONTROL + i;
 
 		/* directly assign to the 1st group */
-		ret = i2c_reg_write_byte_dt(&config->bus, current_led, LP5569_MF_MAPPING_FADER1);
+		ret = i2c_reg_write_byte_dt(&config->bus, current_led,
+					    LP5569_MF_MAPPING_FADER1 | LP5569_EXP_EN);
 		if (ret < 0) {
 			LOG_ERR("Assigning led to MASTER_FADER group failed");
 			return ret;


### PR DESCRIPTION
As described in 8.3.1.1 we can use an exponential brightness curve. This is applied to both the engine and manual PWM registers.

The exponential brightness curve compensates for the human eye that is not perceiving lux in a linear way.

<img width="374" height="307" alt="image" src="https://github.com/user-attachments/assets/339adbc0-1b43-4783-83c7-5e62e3a034f6" />
