### PR TITLE
Add device is deferred init fn

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -787,6 +787,19 @@ __syscall const struct device *device_get_binding(const char *name);
 size_t z_device_get_all_static(const struct device **devices);
 
 /**
+ * @brief Verify that a device was set to a deferred initialization
+ *
+ * Indictase whether the provided device pointer is part of deferred init
+ * device section, indicating its related DTS node has 'zephyr,deferred-init'
+ * attribute set.
+ *
+ * @param dev pointer to the device in question.
+ * @retval true If the device was set to a deferred initialization
+ * @retval false Otherwise
+ */
+__syscall bool device_is_deferred_init(const struct device *dev);
+
+/**
  * @brief Verify that a device is ready for use.
  *
  * Indicates whether the provided device pointer is for a device known to be

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -59,6 +59,14 @@ static inline const struct device *z_vrfy_device_get_binding(const char *name)
 }
 #include <zephyr/syscalls/device_get_binding_mrsh.c>
 
+static inline bool z_vrfy_device_is_deferred_init(const struct device *dev)
+{
+	K_OOPS(K_SYSCALL_OBJ_INIT(dev, K_OBJ_ANY));
+
+	return z_impl_device_is_deferred_init(dev);
+}
+#include <zephyr/syscalls/device_is_deferred_init_mrsh.c>
+
 static inline bool z_vrfy_device_is_ready(const struct device *dev)
 {
 	K_OOPS(K_SYSCALL_OBJ_INIT(dev, K_OBJ_ANY));
@@ -127,6 +135,21 @@ size_t z_device_get_all_static(struct device const **devices)
 	STRUCT_SECTION_COUNT(device, &cnt);
 
 	return cnt;
+}
+
+bool z_impl_device_is_deferred_init(const struct device *dev)
+{
+	if (dev == NULL) {
+		return false;
+	}
+
+	STRUCT_SECTION_FOREACH_ALTERNATE(_deferred_init, init_entry, entry) {
+		if (entry->dev == dev) {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 bool z_impl_device_is_ready(const struct device *dev)

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -405,6 +405,8 @@ ZTEST(device, test_deferred_init)
 {
 	int ret;
 
+	zassert_true(device_is_deferred_init(FAKEDEFERDRIVER0));
+
 	zassert_false(device_is_ready(FAKEDEFERDRIVER0));
 
 	ret = device_init(FAKEDEFERDRIVER0);


### PR DESCRIPTION
This function will be helpful to mitigate (a bit) on device_is_ready() test: if that one fails, it might not be because it failed to init, but just it is not YET initialized because it has been deferred.
